### PR TITLE
Implement incomplete Debian packaging for generating the build and runtime dependencies packages

### DIFF
--- a/misc/.gitignore
+++ b/misc/.gitignore
@@ -1,0 +1,4 @@
+# Don't track built Debian packages and Co.
+*.deb
+*.changes
+*.buildinfo

--- a/misc/README.md
+++ b/misc/README.md
@@ -1,0 +1,3 @@
+# misc
+
+Mischellaneous files that may help in the usage of the application.

--- a/misc/debian/README.md
+++ b/misc/debian/README.md
@@ -1,0 +1,42 @@
+# debian
+
+Incomplete Debian packaging merely for building the build and runtime dependencies packages for clean installation and removal.
+
+## Prerequisites
+
+The following packages must be installed to build the dependency packages:
+
+* devscripts
+* equivs
+
+## Building the build dependency package
+
+1. Launch your preferred terminal.
+1. Change the working directory to _the parent directory_ of the one hosting this document.
+1. Run the following command to build the build dependency package:
+
+    ```bash
+    mk-build-deps
+    ```
+
+   The built build dependency package will be available in the working directory, installing it by running the following command:
+
+    ```bash
+    sudo apt install ./commits-tilewall-build-deps_1.0_all.deb
+    ```
+
+## Building the runtime dependency package
+
+1. Launch your preferred terminal.
+1. Change the working directory to _the parent directory_ of the one hosting this document.
+1. Run the following command to build the build dependency package:
+
+    ```bash
+    equivs-build debian/control
+    ```
+
+   The built runtime dependency package will be available in the working directory, installing it by running the following command:
+
+    ```bash
+    sudo apt install ./commits-tilewall-deps_1.0_all.deb
+    ```

--- a/misc/debian/control
+++ b/misc/debian/control
@@ -1,0 +1,20 @@
+# Incomplete Debian packaging control file for generating the build and runtime dependency packages
+#
+# Copyright 2024 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>
+# SPDX-License-Identifier: CC-BY-SA-4.0
+Source: commits-tilewall
+Priority: optional
+Homepage: https://github.com/brlin-tw/commits-tilewall
+Standards-Version: 3.9.2
+Build-Depends:
+    build-essential
+    ,cargo
+    ,debhelper-compat (= 12)
+    ,libfontconfig-dev
+
+Package: commits-tilewall-deps
+Maintainer: 林博仁(Buo-ren Lin) <buo.ren.lin@gmail.com>
+Depends:
+    git
+    ,libfontconfig1
+


### PR DESCRIPTION
This pull request implements incomplete Debian packaging for generating the build and runtime dependencies packages for clean installation and removal.

This isn't intended to be merged and is just for anyone who needs it without reinventing the wheels.  DO NOT MERGE.