### PR TITLE
Fix snap distribution cannot find commits due to Git error

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -15,6 +15,8 @@ confinement: strict
 issues: https://github.com/fourdollars/commits-tilewall/issues
 website: https://github.com/fourdollars/commits-tilewall
 license: MIT
+assumes:
+  - command-chain
 
 parts:
   commits-tilewall:
@@ -28,9 +30,18 @@ parts:
       - git
       - libfontconfig1
 
+  git-launch:
+    source: https://github.com/brlin-tw/git-launch.git
+    source-tag: v1.0.1
+    plugin: dump
+    stage:
+      - bin/*
+
 apps:
   commits-tilewall:
     command: bin/commits-tilewall
+    command-chain:
+      - bin/git-launch
     plugs:
       - desktop
       - home


### PR DESCRIPTION
This patch introduces the git-launch launcher which sets appropriate environment for Git to function in the snap runtime.

```text
$ snap run commits-tilewall '林博仁' ../WoeUSB
Collecting commit dates for repo: ../WoeUSB
Found commits in years: [2021, 2020]
Commit counts per year: [(2021, 91), (2020, 72)]
Current directory: /home/brlin/文件/commits-tilewall
```

Refer to [the Snapcraft Forum post](https://forum.snapcraft.io/t/the-git-launch-launcher-fix-git-functionality-in-the-snap-runtime-environment/11742) for more information regarding the launcher.

Fixes #6.